### PR TITLE
Use thread-safe native-form release

### DIFF
--- a/opensrp-chw-hivst/build.gradle
+++ b/opensrp-chw-hivst/build.gradle
@@ -193,7 +193,7 @@ dependencies {
 
     implementation 'net.zetetic:sqlcipher-android:4.5.4'
 
-    implementation('org.smartregister:opensrp-client-native-form:3.1.8-NACP-SNAPSHOT') {
+    implementation('org.smartregister:opensrp-client-native-form:3.2.0-NACP-SNAPSHOT') {
         transitive = true
         exclude group: 'com.android.support', module: 'recyclerview-v7'
         exclude group: 'com.android.support', module: 'appcompat-v7'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -91,7 +91,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpmime'
     }
 
-    implementation('org.smartregister:opensrp-client-native-form:1.9.1-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-native-form:3.2.0-NACP-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'com.android.support', module: 'recyclerview-v7'
         exclude group: 'com.android.support', module: 'appcompat-v7'


### PR DESCRIPTION
## Summary

- update the library and sample to `org.smartregister:opensrp-client-native-form:3.2.0-NACP-SNAPSHOT`

## Why

Older native-form builds can call `MaterialEditText.setText()` and `setError()` from the constraint disk executor. That can race Android TextView's layout lifecycle and surface as the reported null `Layout` crash in `Editor.drawHardwareAccelerated()`.

The 3.2.0 NACP release includes the main-thread handoff fix. The corresponding upstream fix is opensrp/opensrp-client-native-form#672; the maintained-fork implementation is Digital-Square-Tanzania/opensrp-client-native-form#4.

## Validation

- dependency insight for `debugCompileClasspath` selects exactly `3.2.0-NACP-SNAPSHOT`
- `:opensrp-chw-hivst:compileDebugJavaWithJavac` passes with Java 11
- `git diff --check` passes

